### PR TITLE
fix to task component - preventing saving empty string

### DIFF
--- a/src/components/task.jsx
+++ b/src/components/task.jsx
@@ -46,7 +46,7 @@ class Task extends Component {
     }
 
     handleClear() {
-        this.setState({taskName: " "})
+        this.setState({taskName: ""})
     }
 
     saveEdit() {


### PR DESCRIPTION
removed extra space when setting taskName in handleClear() within Task component. This now shows the HelpText component if user tries to save an empty string.