### PR TITLE
Add hover state to tasks

### DIFF
--- a/src/assets/modules.scss
+++ b/src/assets/modules.scss
@@ -97,15 +97,22 @@
 
   flex-direction: row;
   justify-content: center;
-  //align-items: flex-start;
+  align-items: center;
 
   padding-bottom: 0.8rem;
   border-bottom: 1px solid #e4e4e4;
+  &:hover {
+    background-color: #e8e8e8;
+    cursor: pointer;
+  }
   li {
     padding: 0 1.2rem;
     width: 100%;
     list-style-type: none;
     font-size: 1.8rem;
+    display: flex;
+    align-items: center;
+
   }
 
   input[type=text] {

--- a/src/components/task.jsx
+++ b/src/components/task.jsx
@@ -76,7 +76,7 @@ class Task extends Component {
 
     render() {
         const textStyle = this.props.task.completed ? 'line-through' : "none"
-        const colorStyle = this.props.task.completed ? 'grey' : "inherit"
+        const colorStyle = this.props.task.completed ? '#BDBDBD' : "inherit"
 
         return (
             <div>


### PR DESCRIPTION
Hovering over a task now causes a grey background. 
I also updated the color of a checked task to be a lighter shade of grey. 
Also adjusted task items to be vertically centered.